### PR TITLE
fix: handle undefined return from store.get() in cacheTails

### DIFF
--- a/src/cacheTails.ts
+++ b/src/cacheTails.ts
@@ -38,7 +38,7 @@ export function cacheTails<T>(
   const t = new TransformStream();
   const w = t.writable.getWriter();
   const writable = new WritableStream({
-    start: async () => cachePromise.resolve(await store.get(key)),
+    start: async () => cachePromise.resolve((await store.get(key)) ?? []),
     write: async (chunk, ctrl) => {
       const cache = await cachePromise.promise;
       if (cache && equals(chunk, cache[0])) {


### PR DESCRIPTION
## Summary
- Fixed TypeScript error in src/cacheTails.ts where store.get() could return undefined
- Added nullish coalescing to default to empty array when store returns undefined

## Test plan
- [x] TypeScript compilation passes without errors for cacheTails.ts
- [x] All existing tests pass (179 tests passing)

🤖 Generated with [Claude Code](https://claude.ai/code)