### PR TITLE
fix: replace Node.js Timer type with browser-compatible type

### DIFF
--- a/src/debounces.ts
+++ b/src/debounces.ts
@@ -1,5 +1,5 @@
 export function debounces<T>(t: number) {
-  let id: number | null | Timer = null;
+  let id: ReturnType<typeof setTimeout> | null = null;
   return new TransformStream<T, T>({
     transform: async (chunk, ctrl) => {
       if (id) clearTimeout(id);

--- a/src/throttles.ts
+++ b/src/throttles.ts
@@ -21,7 +21,7 @@ export function throttles<T>(
   interval: number,
   { drop = false, keepLast = true }: ThrottleOption = {},
 ) {
-  let timerId: number | null | Timer = null;
+  let timerId: ReturnType<typeof setTimeout> | null = null;
   let cdPromise = Promise.withResolvers();
   let lasts: T[] = [];
   return new TransformStream<T, T>({


### PR DESCRIPTION
## Summary
- Fixed TypeScript error when using sflow in browser environments
- Replaced Node.js-specific `Timer` type with browser-compatible `ReturnType<typeof setTimeout>`

## Problem
The package was using the `Timer` type which is Node.js-specific and causes TypeScript errors when the package is used in browser environments:
```
Type error: Cannot find name 'Timer'
```

## Solution
Changed timer ID type from `number | null | Timer` to `ReturnType<typeof setTimeout> | null` in:
- `src/debounces.ts`
- `src/throttles.ts`

This type is compatible with both Node.js and browser environments.

## Test plan
- [x] TypeScript compilation passes without Timer-related errors
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)