### PR TITLE
fix: resolve TypeScript 'unknown' type error in strings.ts

### DIFF
--- a/src/strings.ts
+++ b/src/strings.ts
@@ -54,7 +54,7 @@ export const replaces: {
     TransformStream<string, string>;
 
 } = (searchValue, replacement) => {
-  return maps((s) =>
+  return maps<string, string>((s) =>
     typeof replacement === "string"
       ? s.replace(
         searchValue as any,
@@ -84,7 +84,7 @@ export const replaceAlls: {
     replacer: (substring: string, ...args: any[]) => Promise<string> | string,
   ): TransformStream<string, string>;
 } = (searchValue, replacement) => {
-  return maps((s) =>
+  return maps<string, string>((s) =>
     typeof replacement === "string"
       ? s.replaceAll(searchValue, replacement)
       : replaceAsync(s, searchValue, replacement),


### PR DESCRIPTION
## Summary
- Fixed TypeScript error in `src/strings.ts` where parameter `s` was inferred as type `unknown`
- Added explicit type parameters `<string, string>` to `maps` function calls in both `replaces` and `replaceAlls` functions

## Problem
The `maps` function is a generic function that requires type parameters. Without explicit type parameters, TypeScript was inferring the callback parameter `s` as `unknown`, causing a type error at line 59:
```
Type error: 's' is of type 'unknown'.
```

## Solution
Added explicit type parameters to ensure proper type inference:
- `maps<string, string>((s) => ...)` instead of `maps((s) => ...)`

## Test plan
- [x] Build passes successfully (`npm run build`)
- [x] All tests pass (`bun test`)
- [x] TypeScript compilation shows no errors in strings.ts

🤖 Generated with [Claude Code](https://claude.ai/code)