### PR TITLE
fix: remove react-hook-form peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,9 +93,7 @@
     "typedoc": "^0.28.17",
     "vitest": "^3.2.4"
   },
-  "peerDependencies": {
-    "react-hook-form": "^7.60.0"
-  },
+  "peerDependencies": {},
   "license": "MIT",
   "homepage": "https://github.com/snomiao/sflow#readme",
   "repository": {

--- a/src/FieldPath.ts
+++ b/src/FieldPath.ts
@@ -1,0 +1,16 @@
+/**
+ * Lightweight replacements for react-hook-form's FieldPathByValue / FieldPathValue.
+ * Only the subset needed by sflow (top-level keys) is implemented here.
+ */
+
+/**
+ * All top-level keys of T whose value is assignable to V.
+ */
+export type FieldPathByValue<T, V> = {
+  [K in keyof T & string]: T[K] extends V ? K : never;
+}[keyof T & string];
+
+/**
+ * The value type at key K in T.
+ */
+export type FieldPathValue<T, K extends string> = K extends keyof T ? T[K] : never;

--- a/src/Unwinded.ts
+++ b/src/Unwinded.ts
@@ -1,4 +1,4 @@
-import type { FieldPathByValue, FieldPathValue } from "react-hook-form";
+import type { FieldPathByValue, FieldPathValue } from "./FieldPath";
 
 export type Unwinded<T, K> = T extends Record<string, unknown>
   ? K extends FieldPathByValue<T, ReadonlyArray<unknown>>

--- a/src/sflow.ts
+++ b/src/sflow.ts
@@ -1,6 +1,6 @@
 import DIE from "phpdie";
 import type { Ord } from "./utils";
-import type { FieldPathByValue } from "react-hook-form";
+import type { FieldPathByValue } from "./FieldPath";
 import type { AsyncOrSync } from "ts-essentials";
 import type { Awaitable } from "./Awaitable";
 import { asyncMaps } from "./asyncMaps";


### PR DESCRIPTION
## Summary
- Replace `FieldPathByValue` and `FieldPathValue` type imports from `react-hook-form` with lightweight local equivalents in `src/FieldPath.ts`
- Remove `react-hook-form` from `peerDependencies`
- sflow only used these as type-level utilities for the `unwind()` method — a stream processing library should not depend on a React form library

## Test plan
- [x] All 206 existing tests pass
- [x] Build succeeds
- [x] Type checking passes (types are compile-time only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)